### PR TITLE
Working on android again

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 	xmlns:android="http://schemas.android.com/apk/res/android"
-	id="im.ltdev.cordova.UserAgent"
+	id="cordova-plugin-useragent"
 	version="1.0.1">
 	<engines>
 		<engine name="cordova" version=">=4.0.0" />

--- a/src/android/UserAgent.java
+++ b/src/android/UserAgent.java
@@ -23,7 +23,9 @@ public class UserAgent extends CordovaPlugin {
 
             try{
 
-                settings = ((WebView) webView.getEngine().getView()).getSettings();
+		// another solution here https://github.com/miloproductionsinc/cordova-plugin-useragent/blob/master/src/android/UserAgent.java
+                // settings = ((WebView) webView.getEngine().getView()).getSettings(); // returns null
+                settings = ((WebView) webView.getView()).getSettings();
 
             }catch (Exception error){
 

--- a/src/android/UserAgent.java
+++ b/src/android/UserAgent.java
@@ -24,6 +24,7 @@ public class UserAgent extends CordovaPlugin {
             try{
 
                 // another solution here https://github.com/miloproductionsinc/cordova-plugin-useragent/blob/master/src/android/UserAgent.java
+                // and https://github.com/Samnan/cordova-plugin-useragent/blob/master/src/android/UserAgent.java
                 // settings = ((WebView) webView.getEngine().getView()).getSettings(); // returns null
                 settings = ((WebView) webView.getView()).getSettings();
 

--- a/src/android/UserAgent.java
+++ b/src/android/UserAgent.java
@@ -23,7 +23,7 @@ public class UserAgent extends CordovaPlugin {
 
             try{
 
-		// another solution here https://github.com/miloproductionsinc/cordova-plugin-useragent/blob/master/src/android/UserAgent.java
+                // another solution here https://github.com/miloproductionsinc/cordova-plugin-useragent/blob/master/src/android/UserAgent.java
                 // settings = ((WebView) webView.getEngine().getView()).getSettings(); // returns null
                 settings = ((WebView) webView.getView()).getSettings();
 

--- a/src/android/UserAgent.java
+++ b/src/android/UserAgent.java
@@ -24,7 +24,7 @@ public class UserAgent extends CordovaPlugin {
             try{
 
                 // another solution here https://github.com/miloproductionsinc/cordova-plugin-useragent/blob/master/src/android/UserAgent.java
-                // and https://github.com/Samnan/cordova-plugin-useragent/blob/master/src/android/UserAgent.java
+                // and here https://github.com/Samnan/cordova-plugin-useragent/blob/master/src/android/UserAgent.java
                 // settings = ((WebView) webView.getEngine().getView()).getSettings(); // returns null
                 settings = ((WebView) webView.getView()).getSettings();
 


### PR DESCRIPTION
We were facing the same problem mentioned 2019 at the previos repository:
https://github.com/LouisT/cordova-useragent/issues/8

With this changes the android version should report back the useragent string again.